### PR TITLE
Add Raspberry Pi 5 documentation

### DIFF
--- a/content.de/_index.md
+++ b/content.de/_index.md
@@ -4,7 +4,4 @@ bookHeadingAnchor: false
 layout: landing
 ---
 
-<div class="book-hero">
-
-# HUGO BOOK
-[Hugo](https://gohugo.io) documentation theme as simple as plain book
+## Anleitung für die Bühnentechnik Hausmeistersteuerung

--- a/content.de/docs/_index.md
+++ b/content.de/docs/_index.md
@@ -1,9 +1,9 @@
 ---
 title: Introduction
 bookHeadingAnchor: false
-layout: landing
+layout: taxonomy
 ---
 
-<div class="book-hero">
+# Dokumentation 
 
-# HUGO BOOK
+Auf den folgenden Seiten ist die Funktionsweise, Fehlerbehebung und der generelle Aufbau der aktuellen Hausmeistersteuerung per Home Assistant erläutert. Ich hoffe diese Anleitung wird für die folgenden Benutzer ausreichen, dass sie nicht so schnell wieder abgeschafft werden muss.

--- a/content.de/docs/network/devices/_index.md
+++ b/content.de/docs/network/devices/_index.md
@@ -1,0 +1,3 @@
+---
+bookCollapseSection: true
+---

--- a/content.de/docs/network/devices/raspi-5.md
+++ b/content.de/docs/network/devices/raspi-5.md
@@ -1,0 +1,43 @@
+# Raspberry Pi 5
+
+Dieser Raspberry Pi ist das Herz der Hausmeistersteuerung. Hier ist die eigentliche Instanz von Home Assistant installiert, mithilfe die Hausmeistersteuerung umgesetzt wurde.
+
+> In den folgenden Texten wird die Bezeichnung "Home Asssistant" auch durch das Akronym "Hass" abgekürzt.
+
+## Erscheinungen bei Ausfall
+
+Die Erscheinungen bei einem Ausfall dieses Teilsystems sind nicht so schwer zu unterscheiden von anderen. Einige der Symptome sind hier aufgelistet
+
+- Tablet kann Hass nicht mehr erreichen ([Was tun?](/content.de/docs/troubleshooting/tablet.md))
+- Hass ist auch durch <https://hausmeister.wandelt.party> nicht mehr erreichbar
+- Andere Geräte wie der Beamer sind weiterhin erreichbar
+
+### Hass durch externe URL nicht erreichbar
+
+Dies ist kein eindeutiger Hinweis auf einen Ausfall von Hass, es ist nur ein Hinweis. Dieser Dienst läuft über den privaten Server von Niklas Wandelt und kann jederzeit mal nicht funktionieren. Wenn dies der Fall sein sollte, einfach mal anrufen, dann besprechen wir das weitere Vorgehen. Im Fall eines wirklichen Fehlers im System liegt es natürlich nicht an mir, sondern am Raspberry Pi oder am Netzwerk.
+
+### Andere Geräte sind weiterhin erreichbar, nur Hass nicht
+
+Meist liegt dies an einem lockeren Stecker. Prüfe dazu also folgende Dinge:
+
+- Sind alle Kabel am Pi angeschlossen?
+- Ist das LAN Kabel in einem POE fähigen Anschluss am Switch?
+- Blinken die LEDs am Pi?
+- Steckt eine SD Karte im Pi?
+- Sind die PIN Header frei und nicht kurzgeschlossen?
+
+## Was sollte am Pi angeschlossen sein?
+
+Der Raspberry Pi ist per POE an Strom angeschlossen, das heißt, er bekommt seinen Strom über den Netzwerkanschluss. Wundere dich also nicht, wenn kein seperates Netzteil angeschlossen sein sollte. Außer diesem Netzwerkanschluss wird kein weiterer Anschluss des Pis verwendet. Bitte achte jedoch darauf, dass das LAN Kabel auch in einem **POE fähigen Anschluss** steckt.
+
+## Systemupdates des Raspberry Pis
+
+Etwa jeden Monat ein mal wird der Raspi sich melden, um Updates durchzuführen. Diese sind auf jeden Fall nichts schlimmes, trotzdem sollte hier in jedem Fall vorsicht geboten sein. Bei einem Update sollte die Option "Backup erstellen" vor dem Update auf jeden Fall aktiviert sein.
+
+Um ein Update durchzuführen gilt folgender Ablauf.
+
+1. Admin Account anmelden. Passwort und Nutzername [hier]()
+2. In der linken Seitenleiste die Einstellungen öffnen
+3. Wenn Updates verfügbar sein sollten, werden diese nun ganz oben aufgelistet
+4. Um ein Update auszuführen, einfach auf ein Element aus der Liste klicken
+5. Update Ausführen, indem man auf Bestätigen klickt. Unbedingt dazu den Hinweis aus dem obigen Text lesen.

--- a/content.de/docs/troubleshooting/_index.md
+++ b/content.de/docs/troubleshooting/_index.md
@@ -1,0 +1,7 @@
+---
+weight: 10
+---
+
+# Netzwerktopologie
+
+Die ganze Hausmeistersteuerung basiert auf zwei Raspberry Pis. Auf dem einen läuft [Home Assistant](https://home-assistant.io) und auf dem anderen [OpenWRT](https://openwrt.org). Beide sind per POE mit Strom versorgt.

--- a/content.de/docs/troubleshooting/raspi-5-trouble.md
+++ b/content.de/docs/troubleshooting/raspi-5-trouble.md
@@ -1,0 +1,5 @@
+# Raspberry Pi 5 Fehlerbehebung
+
+## Hilfe, ich habe die Kontakte kurzgeschlossen
+
+Auch wenn man es generell auf jeden Fall vermeiden sollte, kann es trotzdem jedem mal passieren. Wenn dies passiert sein sollte und die Hausmeistersteuerung danach nicht mehr erreichbar sein sollte, ziehe kurz das LAN Kabel aus dem Pi und stecke es wieder rein. Hierdurch wird dieser neugestartet und sollte eigentlich wieder normal hochfahren. Keine Sorge dies kann ruhig auch mal 15 Minuten dauern, das ist nicht ungewöhnlich.

--- a/content.de/docs/troubleshooting/tablet.md
+++ b/content.de/docs/troubleshooting/tablet.md
@@ -1,0 +1,3 @@
+# Tablet Fehlerbehebung
+
+Wenn das Tablet nicht funktionieren sollte, gibt es mehrere Ansätze diese Fehler zu diagnostizieren. Es können verschiedene andere Fehlerursachen auch zu diesem Fehlerbild passen.

--- a/hugo.toml
+++ b/hugo.toml
@@ -96,7 +96,7 @@ enableGitInfo = true
   BookSection = 'docs'
 
   # Here for backwar compatibility, not required.
-  BookRepo = 'https://github.com/alex-shpak/hugo-book/'
+  BookRepo = 'https://github.com/wandeltn/hausmeistersteuerung-docs/'
 
   # (Optional, default none) Set template for commit link for the page. Requires enableGitInfo.
   # When set enabled 'Last Modified' and a link to the commit in the footer of the page.
@@ -106,7 +106,7 @@ enableGitInfo = true
   # (Optional, default none) Set template for edit page link.
   # When set enabled 'Edit this page' link in the footer of the page.
   # Param is executed as template using .Site, .Page and .Path as context.
-  BookEditLink = '{{ .Site.Params.BookRepo }}/edit/main/exampleSite/{{ .Path }}'
+  BookEditLink = '{{ .Site.Params.BookRepo }}/edit/main/{{ .Path }}'
 
   # (Optional, default 'January 2, 2006') Configure the date format used on the pages
   # - In git information


### PR DESCRIPTION
Enhance the documentation for the Raspberry Pi 5, including setup instructions, troubleshooting tips, and network topology details for the Hausmeistersteuerung system. Update links and references to ensure accuracy.